### PR TITLE
perf: run the textUILoop only when the player is in a point

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,4 +1,5 @@
 local activeTextUIs = {}
+local isInPoint = false
 
 ---@param action string
 ---@param data any
@@ -147,9 +148,7 @@ local interact = lib.addKeybind({
 interact:disable(true)
 
 local function textUILoop()
-    if loopActive then return end
-    loopActive = true
-    while next(activeTextUIs) do
+    while next(activeTextUIs) and isInPoint do
         local wait = 100
         local drawing = false
         activepedData = nil
@@ -203,11 +202,13 @@ CreateThread(function()
         })
 
         function point:onEnter()
+            isInPoint = true
             spawnPed(self.pedIndex)
             CreateThread(textUILoop)
         end
 
         function point:onExit()
+            isInPoint = false
             dismissPed(self.pedIndex)
             lib.hideContext()
         end


### PR DESCRIPTION
Simply adds a new bool that changes once a player enters and exits a point.

Making it so the textUILoop only runs when needed the isInPoint bool is true.